### PR TITLE
fix: Hide "StringTableCollection"s if the flag is off

### DIFF
--- a/Assets/Plugins/LocalizationExtension/Editor/Google/StringTableCollection/StringTableCollectionBundle.cs
+++ b/Assets/Plugins/LocalizationExtension/Editor/Google/StringTableCollection/StringTableCollectionBundle.cs
@@ -74,7 +74,6 @@ namespace Tsgcpp.Localization.Extension.Editor.Google
                 serviceProvider: serviceProvider,
                 reporter: reporter,
                 sleepSecondsPerRequest: SleepSecondsPerRequest);
-
         }
 
         private void ValidateProperties()

--- a/Assets/Plugins/LocalizationExtension/Editor/Google/StringTableCollection/StringTableCollectionBundleEditor.cs
+++ b/Assets/Plugins/LocalizationExtension/Editor/Google/StringTableCollection/StringTableCollectionBundleEditor.cs
@@ -72,10 +72,15 @@ namespace Tsgcpp.Localization.Extension.Editor.Google
             };
 
             _showStringTableCollections = EditorGUILayout.Foldout(_showStringTableCollections, "Target \"StringTableCollection\"s", foldoutStyle);
+            if (!_showStringTableCollections)
+            {
+                return;
+            }
 
-            var stringTableCollections = _stringTableCollectionsConverter.Convert(Bundle.TargetFolders);
             using var h = new EditorGUILayout.VerticalScope(GUI.skin.box);
             using var g = new EditorGUI.DisabledGroupScope(true);
+
+            var stringTableCollections = _stringTableCollectionsConverter.Convert(Bundle.TargetFolders);
             foreach (var collection in stringTableCollections)
             {
                 EditorGUILayout.ObjectField(collection, typeof(StringTableCollection), allowSceneObjects: false);


### PR DESCRIPTION
# Changes
- fix: Hide "StringTableCollection"s if the flag is off
- chore: Remove an unnecessary empty line